### PR TITLE
Fix logo url

### DIFF
--- a/src/components/TokenLogo/index.js
+++ b/src/components/TokenLogo/index.js
@@ -2,10 +2,10 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { isAddress } from '../../utils/index.js'
 // import EthereumLogo from '../../assets/eth.png'
-// import PenguinLogo from '../../assets/penguin.png'
+import PenguinLogo from '../../assets/penguin.png'
 
 const EthereumLogo = 'https://info.uniswap.org/static/media/eth.5fc0c9bd.png'
-const PenguinLogo = 'www.gateway.pinata.cloud/ipfs/QmYSFM7NMEMUDJ8ChzrQK5rGDjeHtMg2aFSAtah4bLaw2H'
+// const PenguinLogo = 'www.gateway.pinata.cloud/ipfs/QmYSFM7NMEMUDJ8ChzrQK5rGDjeHtMg2aFSAtah4bLaw2H'
 
 const BAD_IMAGES = {}
 


### PR DESCRIPTION
Correct logo img path

When user tries to view token info at 
https://penguinalytics.eth.link/#/token/
0x30bcd71b8d21fe830e493b30e90befba29de9114
The token logo is NOT showing correctly.

Token logo is @ src/components/TokenLogo/index.js and is currently 
populated w/ 
const PenguinLogo = 
'www.gateway.pinata.cloud/ipfs/
QmYSFM7NMEMUDJ8ChzrQK5rGDjeHtMg2aFSAtah4bLaw2H'

The main logo shows correctly. Logo is @ src/components/Title/index.js 
and is populated with: 
` import Logo from '../../assets/penguin.png' ` 
to populate the 
image.

I have corrected the Token Image issue by changing the PenguinLogo 
const to:
import PenguinLogo from '../../assets/penguin.png' 
and verifying the issue has been corrected locally 

<img width="1440" alt="Screen Shot 2021-04-19 at 8 57 22 PM" src="https://user-images.githubusercontent.com/59103702/115327199-241ae800-a154-11eb-8616-8f67bc56ebf2.png">
<img width="1440" alt="Screen Shot 2021-04-19 at 8 57 24 PM" src="https://user-images.githubusercontent.com/59103702/115327216-2bda8c80-a154-11eb-8f6b-273186c04cb1.png">
